### PR TITLE
correct typos in MIR_Assignment_1.ipynb

### DIFF
--- a/MIR_Assignment_1.ipynb
+++ b/MIR_Assignment_1.ipynb
@@ -300,8 +300,8 @@
         "\n",
         "\n",
         "'''\n",
-        "다음 예제는 순정율로 만든 장화음 소리와 평균율로 만들어진 장화음 소리를 비교하는 것이다.\n",
-        "순정율 함수를 정확하게 구현하였다면 평균율에 비해서 맥놀이 없이 안정적인 소리가 재생된다. \n",
+        "다음 예제는 순정률로 만든 장화음 소리와 평균율로 만들어진 장화음 소리를 비교하는 것이다.\n",
+        "순정률 함수를 정확하게 구현하였다면 평균율에 비해서 맥놀이 없이 안정적인 소리가 재생된다. \n",
         "'''\n",
         "fund_pitch = 60\n",
         "just_intonation_chord = make_just_intonation_triad_in_midi_pitch(fund_pitch)\n",
@@ -324,7 +324,7 @@
       "source": [
         "## 문제3: 셰퍼드 톤 합성하기 (20점)\n",
         "- [셰퍼드 톤 설명 영상](https://youtu.be/LVWTQcZbLgY)\n",
-        "- [Wikipeda](https://en.wikipedia.org/wiki/Shepard_tone)\n",
+        "- [Wikipedia](https://en.wikipedia.org/wiki/Shepard_tone)\n",
         "- 사람이 소리의 높이와 세기를 어떻게 인지하는지를 고려하여 완성한다."
       ]
     },


### PR DESCRIPTION
2024년도 2학기 <딥러닝 기반 음악정보학>(GITA397) 수강생 김광성(A70034)입니다. 다음과 같은 사소한 오타들을 발견하였습니다:
1. '순정율' -> ('순정률')
2. 'Wikipeda' -> ('Wikipedia')